### PR TITLE
Implement server list icon: (#37)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ name = "feather_server"
 version = "0.3.0"
 dependencies = [
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,6 +41,7 @@ derive_deref = "1.1.0"
 feather_codegen = { path = "../codegen" }
 bitflags = "1.1.0"
 fnv = "1.0.6"
+base64 = "0.10.1"
 
 [features]
 nightly = ["specs/nightly"]

--- a/server/src/io/initialhandler.rs
+++ b/server/src/io/initialhandler.rs
@@ -117,7 +117,11 @@ pub struct InitialHandler {
 }
 
 impl InitialHandler {
-    pub fn new(config: Arc<Config>, player_count: Arc<PlayerCount>, server_icon: Arc<Option<String>>) -> Self {
+    pub fn new(
+        config: Arc<Config>,
+        player_count: Arc<PlayerCount>,
+        server_icon: Arc<Option<String>>,
+    ) -> Self {
         Self {
             action_queue: vec![],
 
@@ -208,7 +212,7 @@ fn handle_handshake(ih: &mut InitialHandler, packet: &Handshake) -> Result<(), E
 
 fn handle_request(ih: &mut InitialHandler, packet: &Request) -> Result<(), Error> {
     check_stage(ih, Stage::AwaitRequest, packet.ty())?;
-    let server_icon = (*ih.server_icon).clone().unwrap_or(String::new());
+    let server_icon = (*ih.server_icon).clone().unwrap_or_default();
 
     // Send response packet
     let json = json!({
@@ -617,7 +621,10 @@ mod tests {
     }
 
     fn ih_with_config(config: Config) -> InitialHandler {
-        InitialHandler::new(Arc::new(config), Arc::new(PlayerCount(AtomicUsize::new(0))),
-                            Arc::new(Some(String::from("test"))))
+        InitialHandler::new(
+            Arc::new(config),
+            Arc::new(PlayerCount(AtomicUsize::new(0))),
+            Arc::new(Some(String::from("test"))),
+        )
     }
 }

--- a/server/src/io/initialhandler.rs
+++ b/server/src/io/initialhandler.rs
@@ -100,6 +100,8 @@ pub struct InitialHandler {
     config: Arc<Config>,
     /// The server's player count.
     player_count: Arc<PlayerCount>,
+    /// The server's icon, if any was loaded.
+    server_icon: Arc<Option<String>>,
 
     /// The username of the player, sent
     /// in Login Start.
@@ -115,7 +117,7 @@ pub struct InitialHandler {
 }
 
 impl InitialHandler {
-    pub fn new(config: Arc<Config>, player_count: Arc<PlayerCount>) -> Self {
+    pub fn new(config: Arc<Config>, player_count: Arc<PlayerCount>, server_icon: Arc<Option<String>>) -> Self {
         Self {
             action_queue: vec![],
 
@@ -126,6 +128,7 @@ impl InitialHandler {
 
             config,
             player_count,
+            server_icon,
 
             username: None,
 
@@ -205,6 +208,7 @@ fn handle_handshake(ih: &mut InitialHandler, packet: &Handshake) -> Result<(), E
 
 fn handle_request(ih: &mut InitialHandler, packet: &Request) -> Result<(), Error> {
     check_stage(ih, Stage::AwaitRequest, packet.ty())?;
+    let server_icon = (*ih.server_icon).clone().unwrap_or(String::new());
 
     // Send response packet
     let json = json!({
@@ -218,7 +222,8 @@ fn handle_request(ih: &mut InitialHandler, packet: &Request) -> Result<(), Error
         },
         "description": {
             "text": ih.config.server.motd,
-        }
+        },
+        "favicon": server_icon,
     });
 
     let response = Response::new(json.to_string());
@@ -599,6 +604,7 @@ mod tests {
         InitialHandler::new(
             Arc::new(Config::default()),
             Arc::new(PlayerCount(AtomicUsize::new(0))),
+            Arc::new(Some(String::from("test"))),
         )
     }
 
@@ -606,10 +612,12 @@ mod tests {
         InitialHandler::new(
             Arc::new(Config::default()),
             Arc::new(PlayerCount(AtomicUsize::new(count))),
+            Arc::new(Some(String::from("test"))),
         )
     }
 
     fn ih_with_config(config: Config) -> InitialHandler {
-        InitialHandler::new(Arc::new(config), Arc::new(PlayerCount(AtomicUsize::new(0))))
+        InitialHandler::new(Arc::new(config), Arc::new(PlayerCount(AtomicUsize::new(0))),
+                            Arc::new(Some(String::from("test"))))
     }
 }

--- a/server/src/io/mod.rs
+++ b/server/src/io/mod.rs
@@ -57,6 +57,7 @@ impl NetworkIoManager {
         num_worker_threads: u16,
         config: Arc<Config>,
         player_count: Arc<PlayerCount>,
+        server_icon: Arc<Option<String>>,
     ) -> Self {
         info!(
             "Starting IO event loop on {} with {} worker threads",
@@ -69,8 +70,9 @@ impl NetworkIoManager {
             let (send2, recv2) = channel();
             let player_count = Arc::clone(&player_count);
             let config = Arc::clone(&config);
+            let server_icon = Arc::clone(&server_icon);
 
-            thread::spawn(move || worker::start(recv1, send2, config, player_count));
+            thread::spawn(move || worker::start(recv1, send2, config, player_count, server_icon));
             workers.push((send1, recv2));
         }
 

--- a/server/src/io/worker.rs
+++ b/server/src/io/worker.rs
@@ -33,6 +33,7 @@ struct Worker {
 
     config: Arc<Config>,
     player_count: Arc<PlayerCount>,
+    server_icon: Arc<Option<String>>,
 }
 
 struct ClientHandle {
@@ -60,6 +61,7 @@ pub fn start(
     sender: Sender<ListenerToWorkerMessage>,
     config: Arc<Config>,
     player_count: Arc<PlayerCount>,
+    server_icon: Arc<Option<String>>,
 ) {
     trace!("Starting IO worker thread");
     let poll = Poll::new().unwrap();
@@ -76,6 +78,7 @@ pub fn start(
         pending_disconnects: vec![],
         config,
         player_count,
+        server_icon,
     };
 
     worker
@@ -142,6 +145,7 @@ fn accept_connection(worker: &mut Worker, stream: TcpStream, addr: SocketAddr) {
         initial_handler: Some(InitialHandler::new(
             Arc::clone(&worker.config),
             Arc::clone(&worker.player_count),
+            Arc::clone(&worker.server_icon),
         )),
     };
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,7 +26,6 @@ extern crate feather_codegen;
 extern crate bitflags;
 #[macro_use]
 extern crate feather_core;
-extern crate base64;
 
 extern crate nalgebra_glm as glm;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,6 +26,7 @@ extern crate feather_codegen;
 extern crate bitflags;
 #[macro_use]
 extern crate feather_core;
+extern crate base64;
 
 extern crate nalgebra_glm as glm;
 
@@ -48,7 +49,7 @@ use feather_core::level;
 use feather_core::level::LevelData;
 use shrev::EventChannel;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Write, Read};
 use std::process::exit;
 
 #[global_allocator]
@@ -77,6 +78,7 @@ pub const TICK_TIME: u64 = 1000 / TPS;
 
 #[derive(Default, Debug)]
 pub struct PlayerCount(AtomicUsize);
+
 #[derive(Default, Debug)]
 pub struct TickCount(u64);
 
@@ -94,9 +96,11 @@ fn main() {
         error!("An error occurred, and the server has shut down. Please report this at https://github.com/caelunshun/feather/issues");
     }));
 
+    let server_icon = Arc::new(load_server_icon());
+
     let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
 
-    let io_manager = init_io_manager(Arc::clone(&config), Arc::clone(&player_count));
+    let io_manager = init_io_manager(Arc::clone(&config), Arc::clone(&player_count), Arc::clone(&server_icon));
 
     info!("Loading level.dat");
     let level = load_level().unwrap_or_else(|e| {
@@ -178,12 +182,13 @@ fn run_loop(world: &mut World, dispatcher: &mut Dispatcher) {
 }
 
 /// Starts the IO threads.
-fn init_io_manager(config: Arc<Config>, player_count: Arc<PlayerCount>) -> io::NetworkIoManager {
+fn init_io_manager(config: Arc<Config>, player_count: Arc<PlayerCount>, server_icon: Arc<Option<String>>) -> io::NetworkIoManager {
     io::NetworkIoManager::start(
         format!("127.0.0.1:{}", config.server.port).parse().unwrap(),
         config.io.io_worker_threads,
         config,
         player_count,
+        server_icon,
     )
 }
 
@@ -240,6 +245,29 @@ fn init_log(config: &Config) {
     };
 
     simple_logger::init_with_level(level).unwrap();
+}
+
+/// Tries to load a server icon from the current directory.
+fn load_server_icon() -> Option<String> {
+    let icon_file: Option<File> = match File::open("server-icon.png") {
+        Ok(file) => Some(file),
+        Err(_) => None
+    };
+    if icon_file.is_none() {
+        return None;
+    }
+
+    let mut icon_file = icon_file.unwrap();
+    let mut data = Vec::new();
+
+    if icon_file.read_to_end(&mut data).is_err() {
+        warn!("Failed to load server icon.");
+        return None;
+    }
+
+    let b64_icon = base64::encode(&data);
+
+    return Some(format!("data:image/png;base64,{}", b64_icon));
 }
 
 /// Retrieves the current time in seconds
@@ -314,7 +342,8 @@ mod tests {
     fn test_init_world() {
         let config = Arc::new(Config::default());
         let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
-        let ioman = init_io_manager(Arc::clone(&config), Arc::clone(&player_count));
+        let server_icon = Arc::new(Some(String::from("server_icon")));
+        let ioman = init_io_manager(Arc::clone(&config), Arc::clone(&player_count), Arc::clone(&server_icon));
         let level = LevelData::default();
 
         let (world, mut dispatcher) = init_world(config, player_count, ioman, level);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,7 +49,7 @@ use feather_core::level;
 use feather_core::level::LevelData;
 use shrev::EventChannel;
 use std::fs::File;
-use std::io::{Write, Read};
+use std::io::{Read, Write};
 use std::process::exit;
 
 #[global_allocator]
@@ -100,7 +100,11 @@ fn main() {
 
     let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
 
-    let io_manager = init_io_manager(Arc::clone(&config), Arc::clone(&player_count), Arc::clone(&server_icon));
+    let io_manager = init_io_manager(
+        Arc::clone(&config),
+        Arc::clone(&player_count),
+        Arc::clone(&server_icon),
+    );
 
     info!("Loading level.dat");
     let level = load_level().unwrap_or_else(|e| {
@@ -184,7 +188,11 @@ fn run_loop(world: &mut World, dispatcher: &mut Dispatcher) {
 }
 
 /// Starts the IO threads.
-fn init_io_manager(config: Arc<Config>, player_count: Arc<PlayerCount>, server_icon: Arc<Option<String>>) -> io::NetworkIoManager {
+fn init_io_manager(
+    config: Arc<Config>,
+    player_count: Arc<PlayerCount>,
+    server_icon: Arc<Option<String>>,
+) -> io::NetworkIoManager {
     io::NetworkIoManager::start(
         format!("127.0.0.1:{}", config.server.port).parse().unwrap(),
         config.io.io_worker_threads,
@@ -254,23 +262,19 @@ fn init_log(config: &Config) {
 fn load_server_icon() -> Option<String> {
     let icon_file: Option<File> = match File::open("server-icon.png") {
         Ok(file) => Some(file),
-        Err(_) => None
+        Err(_) => None,
     };
-    if icon_file.is_none() {
-        return None;
-    }
 
-    let mut icon_file = icon_file.unwrap();
+    let mut icon_file = icon_file?;
+
     let mut data = Vec::new();
-
     if icon_file.read_to_end(&mut data).is_err() {
         warn!("Failed to load server icon.");
         return None;
     }
 
     let b64_icon = base64::encode(&data);
-
-    return Some(format!("data:image/png;base64,{}", b64_icon));
+    Some(format!("data:image/png;base64,{}", b64_icon))
 }
 
 /// Retrieves the current time in seconds
@@ -346,7 +350,11 @@ mod tests {
         let config = Arc::new(Config::default());
         let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
         let server_icon = Arc::new(Some(String::from("server_icon")));
-        let ioman = init_io_manager(Arc::clone(&config), Arc::clone(&player_count), Arc::clone(&server_icon));
+        let ioman = init_io_manager(
+            Arc::clone(&config),
+            Arc::clone(&player_count),
+            Arc::clone(&server_icon),
+        );
         let level = LevelData::default();
 
         let (world, mut dispatcher) = init_world(config, player_count, ioman, level);

--- a/server/src/testframework.rs
+++ b/server/src/testframework.rs
@@ -41,7 +41,9 @@ pub fn init_world<'a, 'b>() -> (World, Dispatcher<'a, 'b>) {
     let config = Arc::new(config);
 
     let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
-    let ioman = super::init_io_manager(Arc::clone(&config), Arc::clone(&player_count));
+    let server_icon = Arc::new(None);
+    let ioman = super::init_io_manager(Arc::clone(&config), Arc::clone(&player_count),
+                                       Arc::clone(&server_icon));
     let level = LevelData::default();
 
     super::init_world(config, player_count, ioman, level)

--- a/server/src/testframework.rs
+++ b/server/src/testframework.rs
@@ -42,8 +42,11 @@ pub fn init_world<'a, 'b>() -> (World, Dispatcher<'a, 'b>) {
 
     let player_count = Arc::new(PlayerCount(AtomicUsize::new(0)));
     let server_icon = Arc::new(None);
-    let ioman = super::init_io_manager(Arc::clone(&config), Arc::clone(&player_count),
-                                       Arc::clone(&server_icon));
+    let ioman = super::init_io_manager(
+        Arc::clone(&config),
+        Arc::clone(&player_count),
+        Arc::clone(&server_icon),
+    );
     let level = LevelData::default();
 
     super::init_world(config, player_count, ioman, level)


### PR DESCRIPTION
Implements the server list icon functionality by loading the file at `server-icon.png` and sending it in the server list response packet.

This implementation does not perform any checks on the PNG (format, size, etc.). The client will simply ignore the favicon if the image is invalid.

Protocol reference: https://wiki.vg/Server_List_Ping#Response