### PR TITLE
Basic implementation of chat (#57)

### DIFF
--- a/core/src/network/packet/mod.rs
+++ b/core/src/network/packet/mod.rs
@@ -449,6 +449,11 @@ lazy_static! {
         );
 
         m.insert(
+            PacketId(0x0E, PacketDirection::Clientbound, PacketStage::Play),
+            PacketType::ChatMessageClientbound,
+        );
+
+        m.insert(
             PacketId(0x17, PacketDirection::Clientbound, PacketStage::Play),
             PacketType::SetSlot,
         );

--- a/server/src/player/chat.rs
+++ b/server/src/player/chat.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for PlayerChatSystem {
     fn run(&mut self, data: Self::SystemData) {
         let (mut events, packet_queue) = data;
 
-        // Handle Animation Serverbound packets.
+        // Handle Chat Message Serverbound packets.
         let packets = packet_queue.for_packet(PacketType::ChatMessageServerbound);
 
         for (player, packet) in packets {
@@ -45,7 +45,7 @@ impl<'a> System<'a> for PlayerChatSystem {
 }
 
 /// System for broadcasting chat messages.
-/// This system listens to `PlayerChatSystem`s.
+/// This system listens to `PlayerChatEvent`s.
 #[derive(Default)]
 pub struct ChatBroadcastSystem {
     reader: Option<ReaderId<PlayerChatEvent>>,

--- a/server/src/player/chat.rs
+++ b/server/src/player/chat.rs
@@ -1,0 +1,100 @@
+use shrev::EventChannel;
+use specs::SystemData;
+use specs::{Entities, Entity, Read, ReadStorage, ReaderId, System, World, Write};
+
+use feather_core::network::cast_packet;
+use feather_core::network::packet::implementation::{
+    ChatMessageClientbound, ChatMessageServerbound,
+};
+use feather_core::network::packet::PacketType;
+
+use crate::entity::NamedComponent;
+use crate::network::{send_packet_to_all_players, NetworkComponent, PacketQueue};
+
+/// Event which is triggered when a player sends a chat message.
+#[derive(Debug, Clone)]
+pub struct PlayerChatEvent {
+    pub player: Entity,
+    pub message: String,
+}
+
+/// System for handling Chat Message Serverbound packets
+/// and then triggering a `PlayerChatEvent`.
+pub struct PlayerChatSystem;
+
+impl<'a> System<'a> for PlayerChatSystem {
+    type SystemData = (
+        Write<'a, EventChannel<PlayerChatEvent>>,
+        Read<'a, PacketQueue>,
+    );
+
+    fn run(&mut self, data: Self::SystemData) {
+        let (mut events, packet_queue) = data;
+
+        // Handle Animation Serverbound packets.
+        let packets = packet_queue.for_packet(PacketType::ChatMessageServerbound);
+
+        for (player, packet) in packets {
+            let packet = cast_packet::<ChatMessageServerbound>(&*packet);
+            let message = packet.message.clone();
+
+            let event = PlayerChatEvent { player, message };
+            events.single_write(event);
+        }
+    }
+}
+
+/// System for broadcasting chat messages.
+/// This system listens to `PlayerChatSystem`s.
+#[derive(Default)]
+pub struct ChatBroadcastSystem {
+    reader: Option<ReaderId<PlayerChatEvent>>,
+}
+
+impl<'a> System<'a> for ChatBroadcastSystem {
+    type SystemData = (
+        Read<'a, EventChannel<PlayerChatEvent>>,
+        ReadStorage<'a, NamedComponent>,
+        ReadStorage<'a, NetworkComponent>,
+        Entities<'a>,
+    );
+
+    fn run(&mut self, data: Self::SystemData) {
+        let (events, nameds, networks, entities) = data;
+
+        for event in events.read(&mut self.reader.as_mut().unwrap()) {
+            let player_name = &nameds.get(event.player).unwrap().display_name;
+
+            // Todo: could use a more robust chat-component library.
+            let message_json = json!({
+                "translate": "chat.type.text",
+                "with": [
+                    {"text": player_name},
+                    {"text": event.message},
+                ],
+            })
+            .to_string();
+
+            // Broadcast chat message
+            let packet = ChatMessageClientbound {
+                json_data: message_json,
+                position: 0,
+            };
+
+            send_packet_to_all_players(&networks, &entities, packet, None);
+
+            // Log in the console
+            info!("<{}> {}", player_name, event.message);
+        }
+    }
+
+    fn setup(&mut self, world: &mut World) {
+        Self::SystemData::setup(world);
+
+        self.reader = Some(
+            world
+                .fetch_mut::<EventChannel<PlayerChatEvent>>()
+                .register_reader(),
+        );
+    }
+}

--- a/server/src/player/mod.rs
+++ b/server/src/player/mod.rs
@@ -7,6 +7,8 @@
 mod animation;
 /// Module for broadcasting when a player joins and leaves.
 mod broadcast;
+/// Module for handling and broadcasting chat messages.
+mod chat;
 /// Module for handling the Player Digging packet.
 mod digging;
 /// Module for initializing the necessary components
@@ -31,13 +33,14 @@ pub use digging::{BlockUpdateCause, BlockUpdateEvent, PlayerItemDropEvent};
 
 use crate::player::inventory::SetSlotSystem;
 use crate::systems::{
-    ANIMATION_BROADCAST, BLOCK_BREAK_BROADCAST, CHUNK_CROSS, CHUNK_SEND, CLIENT_CHUNK_UNLOAD,
-    CREATIVE_INVENTORY, DISCONNECT_BROADCAST, EQUIPMENT_SEND, HELD_ITEM_BROADCAST,
-    HELD_ITEM_CHANGE, JOIN_BROADCAST, NETWORK, PLAYER_ANIMATION, PLAYER_DIGGING, PLAYER_INIT,
-    PLAYER_MOVEMENT, RESOURCE_PACK_SEND, SET_SLOT,
+    ANIMATION_BROADCAST, BLOCK_BREAK_BROADCAST, CHAT_BROADCAST, CHUNK_CROSS, CHUNK_SEND,
+    CLIENT_CHUNK_UNLOAD, CREATIVE_INVENTORY, DISCONNECT_BROADCAST, EQUIPMENT_SEND,
+    HELD_ITEM_BROADCAST, HELD_ITEM_CHANGE, JOIN_BROADCAST, NETWORK, PLAYER_ANIMATION, PLAYER_CHAT,
+    PLAYER_DIGGING, PLAYER_INIT, PLAYER_MOVEMENT, RESOURCE_PACK_SEND, SET_SLOT,
 };
 use animation::{AnimationBroadcastSystem, PlayerAnimationSystem};
 use broadcast::{DisconnectBroadcastSystem, JoinBroadcastSystem};
+use chat::{ChatBroadcastSystem, PlayerChatSystem};
 use digging::BlockUpdateBroadcastSystem;
 use digging::PlayerDiggingSystem;
 use init::PlayerInitSystem;
@@ -57,6 +60,7 @@ pub fn init_logic(dispatcher: &mut DispatcherBuilder) {
     dispatcher.add(CreativeInventorySystem, CREATIVE_INVENTORY, &[NETWORK]);
     dispatcher.add(HeldItemChangeSystem, HELD_ITEM_CHANGE, &[NETWORK]);
     dispatcher.add(PlayerMovementSystem, PLAYER_MOVEMENT, &[NETWORK]);
+    dispatcher.add(PlayerChatSystem, PLAYER_CHAT, &[NETWORK]);
 }
 
 pub fn init_handlers(dispatcher: &mut DispatcherBuilder) {
@@ -87,4 +91,5 @@ pub fn init_broadcast(dispatcher: &mut DispatcherBuilder) {
         &[],
     );
     dispatcher.add(SetSlotSystem::default(), SET_SLOT, &[]);
+    dispatcher.add(ChatBroadcastSystem::default(), CHAT_BROADCAST, &[]);
 }

--- a/server/src/systems.rs
+++ b/server/src/systems.rs
@@ -15,7 +15,7 @@ pub const PLAYER_ANIMATION: &str = "player_animation";
 pub const CREATIVE_INVENTORY: &str = "creative_inventory";
 pub const HELD_ITEM_CHANGE: &str = "held_item_change";
 pub const PLAYER_MOVEMENT: &str = "player_movement";
-pub const PLAYER_CHAT: &str = "player.chat";
+pub const PLAYER_CHAT: &str = "player_chat";
 
 pub const CHUNK_CROSS: &str = "chunk_cross";
 pub const PLAYER_INIT: &str = "player_init";

--- a/server/src/systems.rs
+++ b/server/src/systems.rs
@@ -15,6 +15,7 @@ pub const PLAYER_ANIMATION: &str = "player_animation";
 pub const CREATIVE_INVENTORY: &str = "creative_inventory";
 pub const HELD_ITEM_CHANGE: &str = "held_item_change";
 pub const PLAYER_MOVEMENT: &str = "player_movement";
+pub const PLAYER_CHAT: &str = "player.chat";
 
 pub const CHUNK_CROSS: &str = "chunk_cross";
 pub const PLAYER_INIT: &str = "player_init";
@@ -29,6 +30,7 @@ pub const RESOURCE_PACK_SEND: &str = "resource_pack_send";
 pub const CHUNK_SEND: &str = "chunk_send";
 pub const BLOCK_BREAK_BROADCAST: &str = "block_break_broadcast";
 pub const SET_SLOT: &str = "set_slot";
+pub const CHAT_BROADCAST: &str = "chat_broadcast";
 
 // Entity
 pub const ITEM_COLLECT: &str = "item_collect";


### PR DESCRIPTION
Implements handling of the `ChatMessageServerbound` packet, and broadcasting the `ChatMessageClientbound` packet. Largely based on how player animations are implemented.

Closes #57 (unless there is more work in that scope, like chat-components).