### PR TITLE
Set biome from generatorOptions for flat chunks

### DIFF
--- a/core/src/save/level.rs
+++ b/core/src/save/level.rs
@@ -1,5 +1,6 @@
 //! Implements level.dat file loading.
 
+use crate::Biome;
 use feather_items::Item;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -117,7 +118,7 @@ impl Default for SuperflatGeneratorOptions {
                     height: 1,
                 },
             ],
-            biome: String::from("minecraft:plains"),
+            biome: Biome::Plains.identifier().to_string(),
         }
     }
 }

--- a/core/src/world/chunk.rs
+++ b/core/src/world/chunk.rs
@@ -87,6 +87,18 @@ impl Chunk {
         }
     }
 
+    /// Creates a new empty chunk
+    /// with the specified location,
+    /// and filling its biomes with
+    /// the provided `default_biome`.
+    pub fn new_with_default_biome(location: ChunkPosition, default_biome: Biome) -> Self {
+        Self {
+            location,
+            biomes: [default_biome; SECTION_WIDTH * SECTION_HEIGHT],
+            ..Default::default()
+        }
+    }
+
     /// Gets the block at the specified
     /// position in this chunk. The position
     /// is in the chunk's local coordinate
@@ -719,6 +731,27 @@ mod tests {
         }
 
         assert_eq!(chunk.position(), pos);
+    }
+
+    #[test]
+    fn chunk_new_with_default_biome() {
+        let pos = ChunkPosition::new(0, 0);
+        let chunk = Chunk::new_with_default_biome(pos, Biome::Mountains);
+
+        // Confirm that chunk is empty
+        for x in 0..16 {
+            assert!(chunk.section(x).is_none());
+            assert!(chunk.section(x).is_none());
+        }
+
+        assert_eq!(chunk.position(), pos);
+
+        // Confirm that biomes are set
+        for x in 0..16 {
+            for z in 0..16 {
+                assert_eq!(chunk.biome_at(x, z), Biome::Mountains);
+            }
+        }
     }
 
     #[test]

--- a/server/src/worldgen.rs
+++ b/server/src/worldgen.rs
@@ -1,6 +1,6 @@
 use feather_blocks::Block;
 use feather_core::level::SuperflatGeneratorOptions;
-use feather_core::{Chunk, ChunkPosition};
+use feather_core::{Biome, Chunk, ChunkPosition};
 
 pub trait WorldGenerator: Send + Sync {
     /// Generates the chunk at the given position.
@@ -21,7 +21,9 @@ impl WorldGenerator for EmptyWorldGenerator {
 
 impl WorldGenerator for SuperflatWorldGenerator {
     fn generate_chunk(&self, position: ChunkPosition) -> Chunk {
-        let mut chunk = Chunk::new(position);
+        let biome = Biome::from_identifier(self.options.biome.as_str()).unwrap_or(Biome::Plains);
+        let mut chunk = Chunk::new_with_default_biome(position, biome);
+
         let mut y_counter = 0;
         for layer in self.options.clone().layers {
             if layer.height == 0 {
@@ -66,7 +68,9 @@ mod tests {
 
     #[test]
     pub fn test_worldgen_flat() {
-        let options = SuperflatGeneratorOptions::default();
+        let mut options = SuperflatGeneratorOptions::default();
+        options.biome = Biome::Mountains.identifier().to_string();
+
         let chunk_pos = ChunkPosition { x: 1, z: 2 };
         let generator = SuperflatWorldGenerator { options };
         let chunk = generator.generate_chunk(chunk_pos);
@@ -88,6 +92,7 @@ mod tests {
                         Block::Air
                     );
                 }
+                assert_eq!(chunk.biome_at(x, z), Biome::Mountains);
             }
         }
     }


### PR DESCRIPTION
Reads the Biome from SuperflatGeneratorOptions and sets it in the new chunk.