### PR TITLE
Fix der encoding.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "nalgebra 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nalgebra-glm 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ncollide3d 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint-dig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,6 +23,8 @@ serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0.40"
 toml = "0.5.3"
 rsa = "0.1.3"
+# Match RSA git master
+num-bigint = { version = "0.4", features = ["rand", "i128", "u64_digit", "prime", "zeroize"], package = "num-bigint-dig" }
 rsa-der = "0.2.1"
 rand = "0.7.0"
 rand-legacy = { path = "../util/rand-legacy" }

--- a/server/src/io/initialhandler.rs
+++ b/server/src/io/initialhandler.rs
@@ -262,8 +262,12 @@ fn handle_login_start(ih: &mut InitialHandler, packet: &LoginStart) -> Result<()
     // already finished, so we can call `finish` after
     // setting the player's info.
     if ih.config.server.online_mode {
+        use num_bigint::{BigInt, Sign::Plus};
         // Start enabling encryption
-        let der = der::public_key_to_der(&RSA_KEY.n().to_bytes_be(), &RSA_KEY.e().to_bytes_be());
+        let der = der::public_key_to_der(
+            &BigInt::from_biguint(Plus, RSA_KEY.n().clone()).to_signed_bytes_be(),
+            &BigInt::from_biguint(Plus, RSA_KEY.e().clone()).to_signed_bytes_be(),
+        );
 
         let encryption_request = EncryptionRequest::new(
             "".to_string(), // Server ID - always empty
@@ -318,7 +322,11 @@ fn handle_encryption_response(
     ih.action_queue
         .push(Action::EnableEncryption(ih.key.unwrap()));
 
-    let der = der::public_key_to_der(&RSA_KEY.n().to_bytes_be(), &RSA_KEY.e().to_bytes_be());
+    use num_bigint::{BigInt, Sign::Plus};
+    let der = der::public_key_to_der(
+        &BigInt::from_biguint(Plus, RSA_KEY.n().clone()).to_signed_bytes_be(),
+        &BigInt::from_biguint(Plus, RSA_KEY.e().clone()).to_signed_bytes_be(),
+    );
 
     // Perform authentication
     let auth_result = mojang_api::server_auth(


### PR DESCRIPTION
This changes the data sent into rsa-der to be signed data, as expected by that crate.  The issue is at rsa-der/src/lib.rs#L59 where unsigned data is read as signed, everything after that is operating as it's supposed to.

Other options:
  Change rsa-dir to internally read in the data as unsigned, currently the data is read as signed: https://github.com/caelunshun/rsa-der/blob/8c17a00b3b81887c0e25b5cc5ca442754ace14c9/src/lib.rs#L59
  There is a patch for that: https://github.com/caelunshun/rsa-der/files/3599335/0001-This-is-a-minor-change-to-make-sure-the-numbers-load.patch.txt

In my opinion both are equivalent.  This pull has the effect of not altering the rsa-der API, but overall I think the patch is less intrusive.