### PR TITLE
Use BaseEntityData in PlayerData

### DIFF
--- a/core/src/save/entity.rs
+++ b/core/src/save/entity.rs
@@ -104,3 +104,72 @@ pub struct ArrowEntityData {
     #[serde(rename = "crit")]
     pub critical: u8,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_position() {
+        let data = BaseEntityData {
+            position: vec![1.0, 2.0, 3.0],
+            rotation: vec![4.0, 5.0],
+            velocity: vec![6.0, 7.0, 8.0],
+        };
+        let pos = data.read_position().unwrap();
+
+        assert!(pos.x - 1.0 < std::f64::EPSILON);
+        assert!(pos.y - 2.0 < std::f64::EPSILON);
+        assert!(pos.z - 3.0 < std::f64::EPSILON);
+        assert!(pos.yaw - 4.0 < std::f32::EPSILON);
+        assert!(pos.pitch - 5.0 < std::f32::EPSILON);
+        assert!(pos.on_ground);
+    }
+
+    #[test]
+    fn test_read_position_invalid() {
+        let data = BaseEntityData {
+            position: vec![1.0],
+            rotation: vec![4.0, 5.0],
+            velocity: vec![6.0, 7.0, 8.0],
+        };
+        let pos = data.read_position();
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn test_read_position_invalid_rot() {
+        let data = BaseEntityData {
+            position: vec![1.0, 2.0, 3.0],
+            rotation: vec![4.0],
+            velocity: vec![6.0, 7.0, 8.0],
+        };
+        let pos = data.read_position();
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn test_read_velocity() {
+        let data = BaseEntityData {
+            position: vec![1.0, 2.0, 3.0],
+            rotation: vec![4.0, 5.0],
+            velocity: vec![6.0, 7.0, 8.0],
+        };
+        let vel = data.read_velocity().unwrap();
+
+        assert!(vel[0] - 6.0 < std::f64::EPSILON);
+        assert!(vel[1] - 7.0 < std::f64::EPSILON);
+        assert!(vel[2] - 8.0 < std::f64::EPSILON);
+    }
+
+    #[test]
+    fn test_read_velocity_invalid() {
+        let data = BaseEntityData {
+            position: vec![1.0, 2.0, 3.0],
+            rotation: vec![4.0, 5.0],
+            velocity: vec![6.0, 7.0],
+        };
+        let vel = data.read_velocity();
+        assert!(vel.is_none());
+    }
+}

--- a/core/src/save/player_data.rs
+++ b/core/src/save/player_data.rs
@@ -1,7 +1,8 @@
 use std::fs::File;
 
+use crate::entity::BaseEntityData;
 use crate::inventory::SlotIndex;
-use crate::{ItemStack, Position};
+use crate::ItemStack;
 use feather_items::Item;
 use std::io::Read;
 use uuid::Uuid;
@@ -9,12 +10,12 @@ use uuid::Uuid;
 /// Represents the contents of a player data file.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerData {
+    // Inherit base entity data
+    #[serde(flatten)]
+    pub entity: BaseEntityData,
+
     #[serde(rename = "playerGameType")]
     pub gamemode: i32,
-    #[serde(rename = "Pos")]
-    pub position: Vec<f64>,
-    #[serde(rename = "Rotation")]
-    pub rotation: Vec<f32>,
     #[serde(rename = "Inventory")]
     pub inventory: Vec<InventorySlot>,
 }
@@ -61,24 +62,6 @@ impl InventorySlot {
     }
 }
 
-impl PlayerData {
-    /// Reads the position and rotation fields. If the fields are invalid, None is returned.
-    pub fn read_position(self: &PlayerData) -> Option<Position> {
-        if self.position.len() == 3 && self.rotation.len() == 2 {
-            Some(Position {
-                x: self.position[0],
-                y: self.position[1],
-                z: self.position[2],
-                yaw: self.rotation[0],
-                pitch: self.rotation[1],
-                on_ground: true,
-            })
-        } else {
-            None
-        }
-    }
-}
-
 fn load_from_file<R: Read>(reader: R) -> Result<PlayerData, nbt::Error> {
     nbt::from_gzip_reader::<_, PlayerData>(reader)
 }
@@ -102,48 +85,6 @@ mod tests {
 
         let player = load_from_file(cursor).unwrap();
         assert_eq!(player.gamemode, i32::from(Gamemode::Creative.get_id()));
-    }
-
-    #[test]
-    fn test_read_position() {
-        let data = PlayerData {
-            gamemode: 0,
-            position: vec![1.0, 2.0, 3.0],
-            rotation: vec![4.0, 5.0],
-            inventory: vec![],
-        };
-        let pos = data.read_position().unwrap();
-
-        assert!(pos.x - 1.0 < std::f64::EPSILON);
-        assert!(pos.y - 2.0 < std::f64::EPSILON);
-        assert!(pos.z - 3.0 < std::f64::EPSILON);
-        assert!(pos.yaw - 4.0 < std::f32::EPSILON);
-        assert!(pos.pitch - 5.0 < std::f32::EPSILON);
-        assert!(pos.on_ground);
-    }
-
-    #[test]
-    fn test_read_position_invalid() {
-        let data = PlayerData {
-            gamemode: 0,
-            position: vec![1.0],
-            rotation: vec![2.0, 3.0],
-            inventory: vec![],
-        };
-        let pos = data.read_position();
-        assert!(pos.is_none());
-    }
-
-    #[test]
-    fn test_read_position_invalid_rot() {
-        let data = PlayerData {
-            gamemode: 0,
-            position: vec![1.0, 2.0, 3.0],
-            rotation: vec![4.0],
-            inventory: vec![],
-        };
-        let pos = data.read_position();
-        assert!(pos.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up on PR #125. Since PlayerData is also an entity, it now uses BaseEntityData for the essential fields. This removes the duplicated `read_position` function.

This PR also loads velocity for players from the data file.

This PR also moves the tests for `read_position` to `core::save::entity`, and adds tests for `read_velocity`.