### PR TITLE
Create world level.dat when it doesn't exist

### DIFF
--- a/core/src/save/level.rs
+++ b/core/src/save/level.rs
@@ -1,16 +1,19 @@
 //! Implements level.dat file loading.
 
-use crate::Biome;
-use feather_items::Item;
-use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{Read, Write};
+
+use serde::Deserialize;
+
+use feather_items::Item;
+
+use crate::Biome;
 
 /// Root level tag
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct Root {
+pub struct Root {
     #[serde(rename = "Data")]
-    data: LevelData,
+    pub data: LevelData,
 }
 
 /// Represents the contents of a level file.
@@ -158,6 +161,13 @@ impl LevelData {
 pub fn deserialize_level_file<R: Read>(reader: R) -> Result<LevelData, nbt::Error> {
     match nbt::from_gzip_reader::<_, Root>(reader) {
         Ok(root) => Ok(root.data),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn save_level_file<W: Write>(level: &Root, writer: &mut W) -> Result<(), nbt::Error> {
+    match nbt::to_gzip_writer::<_, Root>(writer, level, None) {
+        Ok(_) => Ok(()),
         Err(e) => Err(e),
     }
 }

--- a/core/src/save/player_data.rs
+++ b/core/src/save/player_data.rs
@@ -5,6 +5,7 @@ use crate::inventory::SlotIndex;
 use crate::ItemStack;
 use feather_items::Item;
 use std::io::Read;
+use std::path::Path;
 use uuid::Uuid;
 
 /// Represents the contents of a player data file.
@@ -66,8 +67,9 @@ fn load_from_file<R: Read>(reader: R) -> Result<PlayerData, nbt::Error> {
     nbt::from_gzip_reader::<_, PlayerData>(reader)
 }
 
-pub fn load_player_data(uuid: Uuid) -> Result<PlayerData, nbt::Error> {
-    let file = File::open(format!("world/playerdata/{}.dat", uuid))?;
+pub fn load_player_data(world_dir: &Path, uuid: Uuid) -> Result<PlayerData, nbt::Error> {
+    let file_path = world_dir.join("playerdata").join(format!("{}.dat", uuid));
+    let file = File::open(file_path)?;
     let data = load_from_file(file)?;
     Ok(data)
 }

--- a/core/src/save/region.rs
+++ b/core/src/save/region.rs
@@ -323,9 +323,9 @@ impl std::error::Error for Error {}
 /// This function does not actually load all the chunks
 /// in the region into memory; it only reads the file's
 /// header so that chunks can be retrieved later.
-pub fn load_region(dir: &str, pos: RegionPosition) -> Result<RegionHandle, Error> {
+pub fn load_region(dir: &PathBuf, pos: RegionPosition) -> Result<RegionHandle, Error> {
     let mut file = {
-        let mut buf = PathBuf::from(dir);
+        let mut buf = dir.clone();
         buf.push(format!("region/r.{}.{}.mca", pos.x, pos.z));
 
         File::open(buf.as_path()).map_err(Error::Io)?

--- a/server/config/feather.toml
+++ b/server/config/feather.toml
@@ -45,3 +45,15 @@ level = "debug"
 url = ""
 # Optional SHA1 hash of the resource pack file.
 hash = ""
+
+[world]
+# The name of the directory containing the world.
+name = "world"
+# The generator to use if the world does not exist.
+# Implemented values are: default, flat
+generator = "default"
+# The seed to use if the world does not exist.
+# Leaving this value empty will generate a random seed.
+# If this value is not a valid integer (i64), the string
+# will be converted using a hash function.
+seed = ""

--- a/server/src/chunk_logic.rs
+++ b/server/src/chunk_logic.rs
@@ -86,8 +86,8 @@ impl<'a> System<'a> for ChunkLoadSystem {
         use specs::prelude::SystemData;
 
         let generator = world.fetch_mut::<Arc<dyn WorldGenerator>>().clone();
-        let config = world.fetch_mut::<Arc<Config>>().clone();
-        let world_dir = Path::new(&config.world.name);
+        let world_name = &world.fetch_mut::<Arc<Config>>().world.name.clone();
+        let world_dir = Path::new(world_name);
 
         info!("Starting chunk worker thread");
         let (sender, receiver) = chunkworker::start(world_dir, generator);

--- a/server/src/chunk_logic.rs
+++ b/server/src/chunk_logic.rs
@@ -13,6 +13,7 @@ use feather_core::world::{ChunkMap, ChunkPosition};
 
 use rayon::prelude::*;
 
+use crate::config::Config;
 use crate::entity::EntityDestroyEvent;
 use crate::systems::{CHUNK_HOLD_REMOVE, CHUNK_LOAD, CHUNK_OPTIMIZE, CHUNK_UNLOAD};
 use crate::worldgen::WorldGenerator;
@@ -22,6 +23,7 @@ use hashbrown::HashSet;
 use multimap::MultiMap;
 use specs::storage::BTreeStorage;
 use std::collections::VecDeque;
+use std::path::Path;
 use std::sync::Arc;
 
 /// A handle for interacting with the chunk
@@ -84,9 +86,11 @@ impl<'a> System<'a> for ChunkLoadSystem {
         use specs::prelude::SystemData;
 
         let generator = world.fetch_mut::<Arc<dyn WorldGenerator>>().clone();
+        let config = world.fetch_mut::<Arc<Config>>().clone();
+        let world_dir = Path::new(&config.world.name);
 
         info!("Starting chunk worker thread");
-        let (sender, receiver) = chunkworker::start("world", generator);
+        let (sender, receiver) = chunkworker::start(world_dir, generator);
         world.insert(ChunkWorkerHandle { sender, receiver });
 
         Self::SystemData::setup(world);

--- a/server/src/chunkworker.rs
+++ b/server/src/chunkworker.rs
@@ -14,6 +14,7 @@ use feather_core::region::{RegionHandle, RegionPosition};
 use feather_core::world::chunk::Chunk;
 use feather_core::world::ChunkPosition;
 use hashbrown::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -64,7 +65,7 @@ struct RegionFile {
 struct ChunkWorker {
     /// The directory in which the world
     /// resides
-    dir: String,
+    dir: PathBuf,
 
     /// Channel used to send chunks and errors
     /// back to the server thread
@@ -84,14 +85,14 @@ struct ChunkWorker {
 /// The returned channels can be used
 /// to communicate with the worker.
 pub fn start(
-    world_dir: &str,
+    world_dir: &Path,
     world_gen: Arc<dyn WorldGenerator>,
 ) -> (Sender<Request>, Receiver<Reply>) {
     let (request_tx, request_rx) = crossbeam::channel::unbounded();
     let (reply_tx, reply_rx) = crossbeam::channel::unbounded();
 
     let worker = ChunkWorker {
-        dir: world_dir.to_string(),
+        dir: world_dir.to_path_buf(),
         sender: reply_tx,
         receiver: request_rx,
         open_regions: HashMap::new(),

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -16,6 +16,7 @@ pub struct Config {
     pub gameplay: Gameplay,
     pub log: Log,
     pub resource_pack: ResourcePack,
+    pub world: World,
 }
 
 pub const DEFAULT_CONFIG_STR: &str = include_str!("../config/feather.toml");
@@ -63,6 +64,13 @@ pub struct Log {
 pub struct ResourcePack {
     pub url: String,
     pub hash: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct World {
+    pub name: String,
+    pub generator: String,
+    pub seed: String,
 }
 
 /// Loads the configuration from the given file/
@@ -114,5 +122,14 @@ mod tests {
 
         let log = &config.log;
         assert_eq!(log.level, "debug");
+
+        let resource_pack = &config.resource_pack;
+        assert_eq!(resource_pack.url, "");
+        assert_eq!(resource_pack.hash, "");
+
+        let world = &config.world;
+        assert_eq!(world.name, "world");
+        assert_eq!(world.generator, "default");
+        assert_eq!(world.seed, "");
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -120,6 +120,10 @@ fn main() {
     let world_dir = Path::new(world_name.as_str());
     let level_file = &world_dir.join("level.dat");
     if !world_dir.is_dir() {
+        info!(
+            "World directory '{}' not found, creating it",
+            world_dir.display()
+        );
         // Create directory
         std::fs::create_dir(world_dir).unwrap();
 
@@ -172,10 +176,10 @@ fn load_config() -> Config {
     }
 }
 
-fn create_level(config: &Arc<Config>) -> LevelData {
+fn create_level(config: &Config) -> LevelData {
     let seed = get_seed(config);
     let world_name = &config.world.name;
-    info!("Creating world '{}' with seed {}", world_name, seed);
+    debug!("Using seed {} for world '{}'", seed, world_name);
 
     // TODO: Generate spawn position properly
     LevelData {
@@ -209,7 +213,7 @@ fn create_level(config: &Arc<Config>) -> LevelData {
     }
 }
 
-fn get_seed(config: &Arc<Config>) -> i64 {
+fn get_seed(config: &Config) -> i64 {
     let seed_raw = &config.world.seed;
     // Empty seed: random
     // Seed is valid i64: parse

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,7 +50,7 @@ use crate::worldgen::{
 use backtrace::Backtrace;
 use feather_core::level;
 use feather_core::level::{deserialize_level_file, save_level_file, LevelData, LevelGeneratorType};
-use rand::RngCore;
+use rand::Rng;
 use shrev::EventChannel;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
@@ -219,7 +219,7 @@ fn get_seed(config: &Config) -> i64 {
     // Seed is valid i64: parse
     // Seed is something else: hash
     if seed_raw.is_empty() {
-        rand::thread_rng().next_u64() as i64
+        rand::thread_rng().gen()
     } else {
         match seed_raw.parse::<i64>() {
             Ok(seed_int) => seed_int,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,10 +49,14 @@ use crate::worldgen::{
 };
 use backtrace::Backtrace;
 use feather_core::level;
-use feather_core::level::{LevelData, LevelGeneratorType};
+use feather_core::level::{deserialize_level_file, save_level_file, LevelData, LevelGeneratorType};
+use rand::RngCore;
 use shrev::EventChannel;
+use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
+use std::path::Path;
 use std::process::exit;
 
 #[global_allocator]
@@ -112,8 +116,21 @@ fn main() {
         Arc::clone(&server_icon),
     );
 
-    info!("Loading level.dat");
-    let level = load_level().unwrap_or_else(|e| {
+    let world_name = &config.world.name;
+    let world_dir = Path::new(world_name.as_str());
+    let level_file = &world_dir.join("level.dat");
+    if !world_dir.is_dir() {
+        // Create directory
+        std::fs::create_dir(world_dir).unwrap();
+
+        let level = create_level(&config);
+        let root = level::Root { data: level };
+        let mut level_file = File::create(level_file).unwrap();
+        save_level_file(&root, &mut level_file).unwrap();
+    }
+
+    info!("Loading {}", level_file.to_str().unwrap());
+    let level = load_level(level_file).unwrap_or_else(|e| {
         error!("Error occurred while loading level.dat: {}", e);
         error!("Please ensure that the world directory exists and is not corrupt.");
         exit(1)
@@ -155,10 +172,68 @@ fn load_config() -> Config {
     }
 }
 
+fn create_level(config: &Arc<Config>) -> LevelData {
+    let seed = get_seed(config);
+    let world_name = &config.world.name;
+    info!("Creating world '{}' with seed {}", world_name, seed);
+
+    // TODO: Generate spawn position properly
+    LevelData {
+        allow_commands: false,
+        border_center_x: 0.0,
+        border_center_z: 0.0,
+        border_damage_per_block: 0.0,
+        border_safe_zone: 0.0,
+        border_size: 0.0,
+        clear_weather_time: 0,
+        data_version: 0,
+        day_time: 0,
+        difficulty: 0,
+        difficulty_locked: 0,
+        game_type: 0,
+        hardcore: false,
+        initialized: false,
+        last_played: 0,
+        raining: false,
+        rain_time: 0,
+        seed,
+        spawn_x: 0,
+        spawn_y: 100,
+        spawn_z: 0,
+        thundering: false,
+        thunder_time: 0,
+        time: 0,
+        version: Default::default(),
+        generator_name: config.world.generator.to_string(),
+        generator_options: None,
+    }
+}
+
+fn get_seed(config: &Arc<Config>) -> i64 {
+    let seed_raw = &config.world.seed;
+    // Empty seed: random
+    // Seed is valid i64: parse
+    // Seed is something else: hash
+    if seed_raw.is_empty() {
+        rand::thread_rng().next_u64() as i64
+    } else {
+        match seed_raw.parse::<i64>() {
+            Ok(seed_int) => seed_int,
+            Err(_) => hash_seed(seed_raw.as_str()),
+        }
+    }
+}
+
+fn hash_seed(seed_raw: &str) -> i64 {
+    let mut hasher = DefaultHasher::new();
+    seed_raw.hash(&mut hasher);
+    hasher.finish() as i64
+}
+
 /// Loads the level.dat file for the world.
-fn load_level() -> Result<LevelData, failure::Error> {
-    let file = File::open("world/level.dat")?;
-    let data = level::deserialize_level_file(file)?;
+fn load_level(path: &Path) -> Result<LevelData, failure::Error> {
+    let file = File::open(path)?;
+    let data = deserialize_level_file(file)?;
     Ok(data)
 }
 

--- a/server/src/player/init.rs
+++ b/server/src/player/init.rs
@@ -10,6 +10,7 @@ use hashbrown::HashSet;
 use shrev::{EventChannel, ReaderId};
 use specs::SystemData;
 use specs::{Read, System, World, WriteStorage};
+use std::path::Path;
 use std::sync::Arc;
 
 /// System for initializing the necessary components
@@ -57,10 +58,11 @@ impl<'a> System<'a> for PlayerInitSystem {
             let uuid = event.uuid;
             // If this is a new player, set gamemode to server's default (config)
             let default_gamemode = &config.server.default_gamemode.clone();
+            let world_dir = Path::new(&config.world.name);
 
             debug!("Loading player data for UUID {}", uuid);
             let (gamemode, pos, velocity, inventory_slots) =
-                match feather_core::player_data::load_player_data(uuid) {
+                match feather_core::player_data::load_player_data(world_dir, uuid) {
                     Ok(data) => (
                         Gamemode::from_id(data.gamemode as u8),
                         data.entity.read_position(),


### PR DESCRIPTION
Creates a world if the `world` directory doesn't exist.

For now it will only write the `level.dat` file when creating it for the first time.

I added a config entry to change the world directory feather looks for (defaults to `world`). There's also options for `seed` and `generator`, only used when a new world is being created.