### PR TITLE
Fix stack sizes based on Minecraft implementation

### DIFF
--- a/core/src/inventory.rs
+++ b/core/src/inventory.rs
@@ -115,8 +115,6 @@ pub fn max_size(item: Item) -> u8 {
         | Item::IronHelmet
         | Item::DiamondHelmet
         | Item::Bow
-        | Item::Book
-        | Item::WrittenBook
         | Item::WritableBook
         | Item::FlintAndSteel
         | Item::WhiteBed
@@ -186,6 +184,9 @@ pub fn max_size(item: Item) -> u8 {
         | Item::TntMinecart
         | Item::DiamondHorseArmor
         | Item::GoldenHorseArmor
+        | Item::Saddle
+        | Item::KnowledgeBook
+        | Item::DebugStick
         | Item::IronHorseArmor => 1,
         Item::EnderPearl
         | Item::Snowball
@@ -207,9 +208,10 @@ pub fn max_size(item: Item) -> u8 {
         | Item::BlackBanner
         | Item::Sign
         | Item::ArmorStand
+        | Item::Bucket
+        | Item::WrittenBook
         | Item::Egg => 16,
         _ => 64,
-        // TODO: are we missing some here?
     }
 }
 


### PR DESCRIPTION
This issue closes https://github.com/caelunshun/feather/issues/158.

A search on the 1.14.4 Minecraft client on items that have a defined `maxCount` variable gives a list of items that have a non-standard stack size. Since stack sizes have not been changed from 1.13 to 1.14, the same values apply to 1.13.

There are some rules to determine the stack size:
- If an item has a non-zero `damage` value, the stack size is 1 (e.g. weapons)
- If an item can be damaged or if it is damaged, the stack size is 1 (e.g. tools and armor)

This rule has a lot of exceptions

| Item name | Stack size |
| - | - |
| SHULKER_BOX | 1 |
| WHITE_SHULKER_BOX | 1 |
| ORANGE_SHULKER_BOX | 1 |
| MAGENTA_SHULKER_BOX | 1 |
| LIGHT_BLUE_SHULKER_BOX | 1 |
| YELLOW_SHULKER_BOX | 1 |
| LIME_SHULKER_BOX | 1 |
| PINK_SHULKER_BOX | 1 |
| GRAY_SHULKER_BOX | 1 |
| LIGHT_GRAY_SHULKER_BOX | 1 |
| CYAN_SHULKER_BOX | 1 |
| PURPLE_SHULKER_BOX | 1 |
| BLUE_SHULKER_BOX | 1 |
| BROWN_SHULKER_BOX | 1 |
| GREEN_SHULKER_BOX | 1 |
| RED_SHULKER_BOX | 1 |
| BLACK_SHULKER_BOX | 1 |
| mushroom_stew | 1 |
| oak_sign | 16 |
| spruce_sign | 16 |
| birch_sign | 16 |
| jungle_sign | 16 |
| acacia_sign | 16 |
| dark_oak_sign | 16 |
| bucket | 16 |
| water_bucket | 1 |
| lava_bucket | 1 |
| minecart | 1 |
| saddle | 1 |
| snowball | 16 |
| oak_boat | 1 |
| milk_bucket | 1 |
| pufferfish_bucket | 1 |
| salmon_bucket | 1 |
| cod_bucket | 1 |
| tropical_fish_bucket | 1 |
| chest_minecart | 1 |
| furnace_minecart | 1 |
| egg | 16 |
| CAKE | 1 |
| WHITE_BED | 1 |
| ORANGE_BED | 1 |
| MAGENTA_BED | 1 |
| LIGHT_BLUE_BED | 1 |
| YELLOW_BED | 1 |
| LIME_BED | 1 |
| PINK_BED | 1 |
| GRAY_BED | 1 |
| LIGHT_GRAY_BED | 1 |
| CYAN_BED | 1 |
| PURPLE_BED | 1 |
| BLUE_BED | 1 |
| BROWN_BED | 1 |
| GREEN_BED | 1 |
| RED_BED | 1 |
| BLACK_BED | 1 |
| ender_pearl | 16 |
| potion | 1 |
| writable_book | 1 |
| written_book | 16 |
| enchanted_book | 1 |
| tnt_minecart | 1 |
| hopper_minecart | 1 |
| rabbit_stew | 1 |
| armor_stand | 16 |
| iron_horse_armor | 1 |
| golden_horse_armor | 1 |
| diamond_horse_armor | 1 |
| leather_horse_armor | 1 |
| command_block_minecart | 1 |
| white_banner | 16 |
| orange_banner | 16 |
| magenta_banner | 16 |
| light_blue_banner | 16 |
| yellow_banner | 16 |
| lime_banner | 16 |
| pink_banner | 16 |
| gray_banner | 16 |
| light_gray_banner | 16 |
| cyan_banner | 16 |
| purple_banner | 16 |
| blue_banner | 16 |
| brown_banner | 16 |
| green_banner | 16 |
| red_banner | 16 |
| black_banner | 16 |
| beetroot_soup | 1 |
| splash_potion | 1 |
| lingering_potion | 1 |
| spruce_boat | 1 |
| birch_boat | 1 |
| jungle_boat | 1 |
| acacia_boat | 1 |
| dark_oak_boat | 1 |
| totem_of_undying | 1 |
| knowledge_book | 1 |
| debug_stick | 1 |
| music_disc_13 | 1 |
| music_disc_cat | 1 |
| music_disc_blocks | 1 |
| music_disc_chirp | 1 |
| music_disc_far | 1 |
| music_disc_mall | 1 |
| music_disc_mellohi | 1 |
| music_disc_stal | 1 |
| music_disc_strad | 1 |
| music_disc_ward | 1 |
| music_disc_11 | 1 |
| music_disc_wait | 1 |
| crossbow | 1 |
| suspicious_stew | 1 |
| flower_banner_pattern | 1 |
| creeper_banner_pattern | 1 |
| skull_banner_pattern | 1 |
| mojang_banner_pattern | 1 |
| globe_banner_pattern | 1 |

Maybe the stack size should be an attribute of each item itself, but that is something that should be discussed in a separate issue.