### PR TITLE
convert elevation map to a compile-time value instead of lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_soft_float"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4001a314cf9c48da20f9d782592e5991012ed0ac952ddc73f9e8878cd8ae90da"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +991,7 @@ version = "0.6.0"
 dependencies = [
  "approx 0.3.2",
  "bitvec",
+ "const_soft_float",
  "feather-base",
  "log",
  "num-traits",

--- a/feather/worldgen/Cargo.toml
+++ b/feather/worldgen/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 base = { path = "../base", package = "feather-base" }
 bitvec = "0.21"
+const_soft_float = "0.1.3"
 log = "0.4"
 num-traits = "0.2"
 once_cell = "1"


### PR DESCRIPTION
# TITLE - Convert elevation map to a compile-time value instead of lazily initialized value

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Converts the elevation weight map to use soft floats. This ensures that map is the same on all architectures as hardware specific floating point quirks are ignored, and allows it to be computed at compile time. A test is included with the old code to show that the result is unchanged. 

## Related issues

_Leave empty if none_

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.