### PR TITLE
UnsafeSendSync/ThreadPinned<T>: Data race allowed on T

### DIFF
--- a/feather/old/server/types/src/task.rs
+++ b/feather/old/server/types/src/task.rs
@@ -27,8 +27,8 @@ unsafe impl Send for SyncFn {}
 /// Fake wrapper which causes a value to become `Send` and `Sync`.
 struct UnsafeSendSync<T>(T);
 
-unsafe impl<T> Send for UnsafeSendSync<T> {}
-unsafe impl<T> Sync for UnsafeSendSync<T> {}
+unsafe impl<T: Send> Send for UnsafeSendSync<T> {}
+unsafe impl<T: Sync> Sync for UnsafeSendSync<T> {}
 
 /// Global task manager.
 static TASK_MANAGER: OnceCell<TaskManager> = OnceCell::new();

--- a/feather/plugin-host/src/thread_pinned.rs
+++ b/feather/plugin-host/src/thread_pinned.rs
@@ -41,5 +41,5 @@ impl<T> ThreadPinned<T> {
     }
 }
 
-unsafe impl<T> Send for ThreadPinned<T> {}
-unsafe impl<T> Sync for ThreadPinned<T> {}
+unsafe impl<T: Send> Send for ThreadPinned<T> {}
+unsafe impl<T: Sync> Sync for ThreadPinned<T> {}


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`ThreadPinned<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.

https://github.com/feather-rs/feather/blob/2f99d76aaad022e65550c88594b7b9b259503c16/feather/plugin-host/src/thread_pinned.rs#L44-L45

same
https://github.com/feather-rs/feather/blob/2f99d76aaad022e65550c88594b7b9b259503c16/feather/old/server/types/src/task.rs#L30-L31